### PR TITLE
upgrade to Flask 2.0.0 for migrate storage example

### DIFF
--- a/migrate-storage/requirements.txt
+++ b/migrate-storage/requirements.txt
@@ -9,7 +9,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-Flask==0.12.2
+Flask==2.0.0
 Flask-WTF==0.14.2
 google==2.0.1
 google-api-core==1.1.0


### PR DESCRIPTION
The older version of Flask seems to now have a bug with receiving json objects properly in Cloud Functions.

@yuriatgoogle would you mind reviewing? This change fixes the Qwiklab we use this repo in, but I'm unsure if it affects anything else.