### PR TITLE
upgrade google-api-core to v1.31.4

### DIFF
--- a/migrate-storage/requirements.txt
+++ b/migrate-storage/requirements.txt
@@ -12,7 +12,7 @@
 Flask==2.0.0
 Flask-WTF==0.14.2
 google==2.0.1
-google-api-core==1.1.0
+google-api-core==1.31.4
 google-api-python-client==1.7.7
 google-auth==1.4.1
 google-auth-httplib2==0.0.3


### PR DESCRIPTION
The current pinned version (1.1.0) is causing deployment issues in the lab.